### PR TITLE
Remove shebang from pagesizes/__init__.py

### DIFF
--- a/domdf_python_tools/pagesizes/__init__.py
+++ b/domdf_python_tools/pagesizes/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 #  __init__.py
 """


### PR DESCRIPTION
The `pagesizes/__init__.py` file cannot be executed:
```
$ chmod +x domdf_python_tools/pagesizes/__init__.py
$ domdf_python_tools/pagesizes/__init__.py
Traceback (most recent call last):
  File "/tmp/domdf_python_tools/domdf_python_tools/pagesizes/__init__.py", line 42, in <module>
    from .classes import *  # noqa: F401
ImportError: attempted relative import with no known parent package
$
```
So technically the shebang in the file is wrong.  This change removes the shebang.